### PR TITLE
Show accordion header description on mouse over title

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -213,10 +213,9 @@ export class SettingsFormEditor extends React.Component<
               elementPosition="center"
               className="jp-SettingsTitle-caret"
             />
-            <h2>{this.props.settings.schema.title}</h2>
-            <div className="jp-SettingsHeader-description">
-              {this.props.settings.schema.description}
-            </div>
+            <h2 title={this.props.settings.schema.description}>
+              {this.props.settings.schema.title}
+            </h2>
           </header>
           {this.state.isModified && (
             <button className="jp-RestoreButton" onClick={this.reset}>

--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -248,14 +248,6 @@ ul.jp-PluginList li.jp-mod-selected span.jp-PluginList-icon.jp-FileIcon {
   font-weight: 300;
 }
 
-.jp-SettingsPanel .jp-SettingsHeader-description {
-  font-size: var(--jp-content-font-size1);
-  color: var(--jp-ui-font-color1);
-  font-weight: 200;
-  margin: 1em;
-  line-height: var(--jp-content-font-size3);
-}
-
 .jp-SettingsPanel .jp-SettingsTitle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
For standard extensions in Settings Editor, header description (2nd part of the header) duplicates  header title (1st part of the header). This will remove header description and only show it on mouse over

Before:
![Screenshot 2023-02-23 at 4 55 54 PM](https://user-images.githubusercontent.com/26686070/221068275-7739ebe0-7f7e-4e0f-916d-eed261ec5cf3.png)

After:
![Screenshot 2023-02-23 at 5 12 13 PM](https://user-images.githubusercontent.com/26686070/221068312-4ecbaa50-5511-46f1-97d3-54f4cd0b5fac.png)
